### PR TITLE
fix(release): Only upload production code to NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
     "description": "",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
+    "files": [
+        "CHANGELOG.md",
+        "dist"
+    ],
     "scripts": {
         "test": "jest",
         "clean": "rm -rf dist",


### PR DESCRIPTION
Fixes #215 

After this, the only files included in the npm package for users to download would be:
- `README.md` (automatic)
- `LICENSE` (automatic)
- `package.json` (automatic)
- `CHANGELOG.md`
- `dist/index.js`, `dist/index.d.ts`, `dist/index.js.map`