### PR TITLE
fix(release): Fix formating of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "build": "yarn -s run clean && yarn -s run check && tsc -p tsconfig.build.json",
         "lint": "biome check --config-path ./biome.json",
         "semantic-release": "semantic-release",
-        "prepublishOnly": "yarn run build"
+        "prepublishOnly": "yarn -s run lint --write && yarn -s run build"
     },
     "private": false,
     "repository": {


### PR DESCRIPTION
Running `yarn build` during the `prepublishOnly` fails because the
package.json is re-formatted when the version is bumped

Run `yarn lint --write` to fix the formatting before running the build
command

Blame: https://github.com/Dintero/money/pull/254
