### PR TITLE
feat: support setting fractionless exponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ export type AdditionalOptions = {
     tags?: Partial<Tags>; // Tag your money to keep track of what it represents
 };
 
+export type FractionLessAdditionalOptions = AdditionalOptions & {
+    exponent?: number;
+};
+
 export declare class Money {
     constructor(data: MoneyInputData);
 
@@ -233,11 +237,14 @@ export declare class Money {
      *
      * Example:
      * Money.fromFractionlessAmount(1000, 'NOK') => 10.00 NOK
+     * Money.fromFractionlessAmount(1000, "NOK", { exponent: 3}) => 1.00 NOK
+     * Money.fromFractionlessAmount(1000, "NOK", { exponent: 3, decimals: 3}) => 1.000 NOK
+     * 
      */
     static fromFractionlessAmount(
         amount: number,
         currency: string,
-        options?: AdditionalOptions,
+        options?: FractionLessAdditionalOptions,
     ): Money;
     /**
      * A price has arbitrary precision.

--- a/src/__tests__/money.test.ts
+++ b/src/__tests__/money.test.ts
@@ -48,6 +48,26 @@ describe("money", () => {
         expect(result).toBe("0.0600000000");
     });
 
+    it("should keep higher precicion fromPrice", () => {
+        const result = Money.fromPrice(2.164727, "NOK", { decimals: 6 });
+        expect(result.toString()).toBe("2.164727");
+    });
+
+    it("should keep higher precicion from fractionless when explicitly set", () => {
+        const result = Money.fromFractionlessAmount(2164727, "NOK", {
+            exponent: 6,
+            decimals: 6,
+        });
+        expect(result.toString()).toBe("2.164727");
+    });
+
+    it("should import with higher precision from fractionless, but round when decimals not set", () => {
+        const result = Money.fromFractionlessAmount(2165727, "NOK", {
+            exponent: 6,
+        });
+        expect(result.toString()).toBe("2.17");
+    });
+
     it("should be able to convert large numbers within double precision", () => {
         Money.of("1234567891234.25", "NOK").toNumber();
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,10 @@ export type AdditionalOptions = {
     tags?: Partial<Tags>;
 };
 
+export type FractionLessAdditionalOptions = AdditionalOptions & {
+    exponent?: number;
+};
+
 export type MoneyInputData = {
     amount: NumberInput;
     currency: string;
@@ -36,7 +40,22 @@ type MoneyData = {
 
 const DEFAULT_DECIMALS_PRICE = 10;
 
-const currencyToDecimals = (currency: string): number => {
+const isOptionsWithExponent = (
+    options: AdditionalOptions | FractionLessAdditionalOptions | undefined,
+): options is Required<Pick<FractionLessAdditionalOptions, "exponent">> => {
+    return (
+        options !== undefined &&
+        (options as FractionLessAdditionalOptions).exponent !== undefined
+    );
+};
+
+const currencyToDecimals = (
+    currency: string,
+    options?: AdditionalOptions | FractionLessAdditionalOptions,
+): number => {
+    if (isOptionsWithExponent(options)) {
+        return options.exponent;
+    }
     const decimals = cc.code(currency)?.digits;
     if (decimals === undefined) {
         if (currency === "UNKNOWN") {
@@ -150,10 +169,10 @@ export class Money {
     static fromFractionlessAmount(
         amount: number,
         currency: string,
-        options?: AdditionalOptions,
+        options?: FractionLessAdditionalOptions,
     ): Money {
         return Money.of(amount, currency, options).divide(
-            10 ** currencyToDecimals(currency),
+            10 ** currencyToDecimals(currency, options),
         );
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export type AdditionalOptions = {
     tags?: Partial<Tags>;
 };
 
-export type FractionLessAdditionalOptions = AdditionalOptions & {
+export type FractionlessAdditionalOptions = AdditionalOptions & {
     exponent?: number;
 };
 
@@ -41,17 +41,17 @@ type MoneyData = {
 const DEFAULT_DECIMALS_PRICE = 10;
 
 const isOptionsWithExponent = (
-    options: AdditionalOptions | FractionLessAdditionalOptions | undefined,
-): options is Required<Pick<FractionLessAdditionalOptions, "exponent">> => {
+    options: AdditionalOptions | FractionlessAdditionalOptions | undefined,
+): options is Required<Pick<FractionlessAdditionalOptions, "exponent">> => {
     return (
         options !== undefined &&
-        (options as FractionLessAdditionalOptions).exponent !== undefined
+        (options as FractionlessAdditionalOptions).exponent !== undefined
     );
 };
 
 const currencyToDecimals = (
     currency: string,
-    options?: AdditionalOptions | FractionLessAdditionalOptions,
+    options?: AdditionalOptions | FractionlessAdditionalOptions,
 ): number => {
     if (isOptionsWithExponent(options)) {
         return options.exponent;
@@ -169,7 +169,7 @@ export class Money {
     static fromFractionlessAmount(
         amount: number,
         currency: string,
-        options?: FractionLessAdditionalOptions,
+        options?: FractionlessAdditionalOptions,
     ): Money {
         return Money.of(amount, currency, options).divide(
             10 ** currencyToDecimals(currency, options),


### PR DESCRIPTION
Support importing a number from fractionless where the accuracy is higher than the lowest exponent of the currency.

Example:

```
Money.fromFractionlessAmount(1000, "NOK")
// 10.00

Money.fromFractionlessAmount(1000, "NOK", { exponent: 3})
// 1.00

Money.fromFractionlessAmount(1000, "NOK", { exponent: 3, decimals: 3})
// 1.000
```
