### PR TITLE
fix: preserve total's sign in distributeBy rest correction

### DIFF
--- a/src/__tests__/money.test.ts
+++ b/src/__tests__/money.test.ts
@@ -153,6 +153,46 @@ describe("money", () => {
         assert.equal(parts[1].toNumber(), 6.42);
     });
 
+    test("should not produce parts with sign opposite to the total when half-up rounding overshoots", () => {
+        // Regression: with a small total and uneven weights, the rounded
+        // parts can overshoot the total (sum 2.70 vs 2.69) and the rest
+        // distribution would naively turn a 0.00-rounded part into -0.01,
+        // breaking sign(parts[i]) == sign(total) and producing a Money the
+        // caller cannot use as a weight in a subsequent distributeBy.
+        const parts = Money.fromFractionlessAmount(269, "NOK").distributeBy([
+            100, 100, 57900, 9400, 74900, 9400,
+        ]);
+        assert.equal(
+            parts.reduce((p, c) => c.add(p), Money.of(0, "NOK")).toNumber(),
+            2.69,
+        );
+        for (const p of parts) {
+            assert.ok(
+                !p.isNegative(),
+                `expected non-negative part, got ${p.toString()}`,
+            );
+        }
+    });
+
+    test("should not produce positive parts when distributing a negative total", () => {
+        // Symmetric case: when the total is negative and rounding overshoots
+        // toward zero, the rest correction must not push a 0.00-rounded part
+        // to +0.01.
+        const parts = Money.fromFractionlessAmount(-269, "NOK").distributeBy([
+            100, 100, 57900, 9400, 74900, 9400,
+        ]);
+        assert.equal(
+            parts.reduce((p, c) => c.add(p), Money.of(0, "NOK")).toNumber(),
+            -2.69,
+        );
+        for (const p of parts) {
+            assert.ok(
+                !p.isPositive(),
+                `expected non-positive part, got ${p.toString()}`,
+            );
+        }
+    });
+
     test("should instantiate from fractionless amount", () => {
         const result = Money.fromFractionlessAmount(1000, "NOK").toString();
         assert.equal(result, "10.00");

--- a/src/index.ts
+++ b/src/index.ts
@@ -522,11 +522,37 @@ export class Money {
             .divide(10 ** this.getDecimals())
             .multiply(rest.isPositive() ? 1 : -1);
 
+        // The half-up rounding above can push the sum of parts past `this`,
+        // so the loop must subtract (or add when this is negative) smallest
+        // units to make up the difference. We must never push a part to a
+        // sign opposite of the total: a part with a tiny exact share rounds
+        // to 0, and naively adding the rest-correction would flip its sign.
+        // Skip such positions; capacity for |rest| always exists in the
+        // parts that already share the total's sign.
+        const totalIsPositive = this.isPositive();
+        const totalIsNegative = this.isNegative();
+
         let i = 0;
+        let skipsInARow = 0;
         while (!rest.isZero()) {
             if (!weights[i].eq(0)) {
-                parts[i] = parts[i].add(smallestUnit);
-                rest = rest.subtract(smallestUnit);
+                const candidate = parts[i].add(smallestUnit);
+                const flipsSign =
+                    (totalIsPositive && candidate.isNegative()) ||
+                    (totalIsNegative && candidate.isPositive());
+                if (!flipsSign) {
+                    parts[i] = candidate;
+                    rest = rest.subtract(smallestUnit);
+                    skipsInARow = 0;
+                } else {
+                    skipsInARow++;
+                    // Defensive bound: capacity analysis says this is
+                    // unreachable, but don't risk an infinite loop on a
+                    // pathological input.
+                    if (skipsInARow >= weights.length) {
+                        break;
+                    }
+                }
             }
             i = (i + 1) % weights.length;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -546,11 +546,15 @@ export class Money {
                     skipsInARow = 0;
                 } else {
                     skipsInARow++;
-                    // Defensive bound: capacity analysis says this is
-                    // unreachable, but don't risk an infinite loop on a
-                    // pathological input.
+                    // By the rounding-bound argument this is unreachable:
+                    // |rest| <= N * smallestUnit and same-sign parts can
+                    // always absorb |rest| without crossing zero. If it
+                    // ever does happen, fail fast rather than silently
+                    // return a distribution that breaks sum(parts) === this.
                     if (skipsInARow >= weights.length) {
-                        break;
+                        throw new Error(
+                            "distributeBy: unable to distribute remainder without flipping a part's sign",
+                        );
                     }
                 }
             }


### PR DESCRIPTION
- `Money.distributeBy` could return a part with the **sign opposite to the total** when the rounded proportional shares overshot and a part rounded to `0.00` happened to be the first weighted index the rest-correction loop visited.
- Skip positions where the smallest-unit adjustment would flip a part's sign relative to the total. By the rounding-bound argument the capacity always exists in same-sign parts, so the loop still terminates.
- Add regression tests for both positive and negative totals.

## Reproducer

```ts
Money.fromFractionlessAmount(269, \"NOK\")
    .distributeBy([100, 100, 57900, 9400, 74900, 9400])
// before: ['-0.01', '0.00', '1.03', '0.17', '1.33', '0.17']
// after:  ['0.00',  '0.00', '1.02', '0.17', '1.33', '0.17']
```

Both versions sum to 2.69 NOK (the invariant `sum(parts) === this` is preserved either way) — but the \"before\" output violates the implicit invariant that callers rely on: parts share the sign of the total. Returning a negative part for a positive total made the result unusable as a weight in a subsequent `distributeBy` call.